### PR TITLE
2 fixs and 1 feature

### DIFF
--- a/Adafruit_Video_Looper/omxplayer.py
+++ b/Adafruit_Video_Looper/omxplayer.py
@@ -27,13 +27,15 @@ class OMXPlayer(object):
         """Return list of supported file extensions."""
         return self._extensions
 
-    def play(self, movie, loop=False):
+    def play(self, movie, loop=False, vol=0):
         """Play the provided movied file, optionally looping it repeatedly."""
         self.stop(3)  # Up to 3 second delay to let the old player stop.
         # Assemble list of arguments.
         args = ['omxplayer']
         args.extend(['-o', self._sound])  # Add sound arguments.
         args.extend(self._extra_args)     # Add extra arguments from config.
+	if vol is not 0:
+	    args.extend(['--vol', str(vol)])
         if loop:
             args.append('--loop')         # Add loop parameter if necessary.
         args.append(movie)                # Add movie file path.

--- a/Adafruit_Video_Looper/video_looper.py
+++ b/Adafruit_Video_Looper/video_looper.py
@@ -61,7 +61,11 @@ class VideoLooper(object):
         self._fgcolor = map(int, self._config.get('video_looper', 'fgcolor') \
                                              .translate(None, ',') \
                                              .split())
-        # Initialize pygame and display a blank screen.
+        # Load sound volume file name value
+	self._sound_vol_file = self._config.get('omxplayer', 'sound_vol_file');
+	# default value to 0 millibels (omxplayer)
+        self._sound_vol = 0
+	# Initialize pygame and display a blank screen.
         pygame.display.init()
         pygame.font.init()
         pygame.mouse.set_visible(False)
@@ -91,6 +95,13 @@ class VideoLooper(object):
         return importlib.import_module('.' + module, 'Adafruit_Video_Looper') \
             .create_file_reader(self._config)
 
+    def _is_number(iself, s):
+	try:
+		float(s) 
+		return True
+	except ValueError:
+		return False
+    
     def _build_playlist(self):
         """Search all the file reader paths for movie files with the provided
         extensions.
@@ -104,12 +115,23 @@ class VideoLooper(object):
                 # Skip paths that don't exist or are files.
                 if not os.path.exists(path) or not os.path.isdir(path):
                     continue
+		# Ignore hidden files (useful when file loaded on usb
+		# key from an OSX computer
                 movies.extend(['{0}/{1}'.format(path.rstrip('/'), x) \
                                for x in os.listdir(path) \
                                if re.search('\.{0}$'.format(ex), x, 
-                                            flags=re.IGNORECASE)])
+                                            flags=re.IGNORECASE) and \
+				x[0] is not '.'])
+		# Get the video volume from the file in the usb key
+		sound_vol_file_path = '{0}/{1}'.format(path.rstrip('/'), self._sound_vol_file)
+		if os.path.exists(sound_vol_file_path):
+			sound_file = open(sound_vol_file_path, 'r')
+			sound_vol_string = sound_file.readline()
+			if self._is_number(sound_vol_string):
+				self._sound_vol = int(float(sound_vol_string))
         # Create a playlist with the sorted list of movies.
         return Playlist(sorted(movies))
+   
 
     def _blank_screen(self):
         """Render a blank screen filled with the background color."""
@@ -193,7 +215,7 @@ class VideoLooper(object):
                 if movie is not None:
                     # Start playing the first available movie.
                     self._print('Playing movie: {0}'.format(movie))
-                    self._player.play(movie, loop=playlist.length() == 1)                    
+                    self._player.play(movie, loop=playlist.length() == 1, vol = self._sound_vol)
             # Check for changes in the file search path (like USB drives added)
             # and rebuild the playlist.
             if self._reader.is_changed():
@@ -203,7 +225,7 @@ class VideoLooper(object):
                 playlist = self._build_playlist()
                 self._prepare_to_run_playlist(playlist)
             # Give the CPU some time to do other tasks.
-            time.sleep(0)
+            time.sleep(0.002)
 
     def signal_quit(self, signal, frame):
         """Shut down the program, meant to by called by signal handler."""

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,7 @@ rm -rf pi_hello_video
 
 echo "Installing video_looper program..."
 echo "=================================="
+mkdir -p /mnt/usbdrive0 # This is very important if you put your system in readonly after
 python setup.py install --force
 cp video_looper.ini /boot/video_looper.ini
 

--- a/remount_rw_usbkey.sh
+++ b/remount_rw_usbkey.sh
@@ -1,0 +1,1 @@
+sudo mount -o remount ,rw /mnt/usbdrive0

--- a/video_looper.ini
+++ b/video_looper.ini
@@ -79,11 +79,10 @@ sound = both
 #sound = hdmi
 #sound = local
 
-# Sound level output for omxplayer will be read from the "sound_level_file" near
-# the video files. If the file does not exist, it will be created with a default
-# level of 0db
+# Sound volume output for the video player will be read from  a  file  near  the
+# video files. If the file does not exist, a default volume of 0db will be  used
 
-sound_level_file = omxplayer_sound_level.ini
+sound_vol_file = sound_volume
 
 # Any extra command line arguments to pass to omxplayer.  It is not recommended
 # that you change this unless you have a specific need to do so!  The audio and

--- a/video_looper.ini
+++ b/video_looper.ini
@@ -79,6 +79,12 @@ sound = both
 #sound = hdmi
 #sound = local
 
+# Sound level output for omxplayer will be read from the "sound_level_file" near
+# the video files. If the file does not exist, it will be created with a default
+# level of 0db
+
+sound_level_file = omxplayer_sound_level.ini
+
 # Any extra command line arguments to pass to omxplayer.  It is not recommended
 # that you change this unless you have a specific need to do so!  The audio and
 # video FIFO buffers are kept low to reduce clipping ends of movie at loop.


### PR DESCRIPTION
# Fix :

- Better performance by adding sleep(0.002) (2ms sleep)
   -> system goes from 20% normal use to 40% instead of 100% with a sleep(0)
- Ignoring hidden files (i.e. beginning with a '.') because when loading videos from a mac computer the pi sees more files than it ought to

# Feature

- Read a value in a text file in the usbkey/directory and use it as the sound volume when playing video (so of course that works for omxplayer or any future video player handling sound)
    -> warning : I did not test with the other video player, so I don't know if it gets broken or not by this new feature, (normally not of course)
// Comments and name of text files are in the .ini config

# Add

Added a script to remount the usb key in read write mode, useful when developping and testing