### PR TITLE
Add option for a background image between videos

### DIFF
--- a/Adafruit_Video_Looper/video_looper.py
+++ b/Adafruit_Video_Looper/video_looper.py
@@ -70,8 +70,9 @@ class VideoLooper(object):
         pygame.display.init()
         pygame.font.init()
         pygame.mouse.set_visible(False)
-        size = (pygame.display.Info().current_w, pygame.display.Info().current_h)
+        size = self._size = (pygame.display.Info().current_w, pygame.display.Info().current_h)
         self._screen = pygame.display.set_mode(size, pygame.FULLSCREEN)
+        self._bgimage = self._load_bgimage()
         self._blank_screen()
         # Set other static internal state.
         self._extensions = self._player.supported_extensions()
@@ -95,6 +96,17 @@ class VideoLooper(object):
         module = self._config.get('video_looper', 'file_reader')
         return importlib.import_module('.' + module, 'Adafruit_Video_Looper') \
             .create_file_reader(self._config)
+
+    def _load_bgimage(self):
+        """Load the configured background image and return an instance of it."""
+        image = None
+        if self._config.has_option('video_looper', 'bgimage'):
+            image = self._config.get('video_looper', 'bgimage')
+            print 'Use ' + str(image) + ' as a background'
+	    image = pygame.image.load(image) 
+	    image = pygame.transform.scale(image, self._size)
+        return image
+        
 
     def _is_number(iself, s):
         try:
@@ -136,6 +148,9 @@ class VideoLooper(object):
     def _blank_screen(self):
         """Render a blank screen filled with the background color."""
         self._screen.fill(self._bgcolor)
+        if self._bgimage is not None:
+          rect = self._bgimage.get_rect()
+	  self._screen.blit(self._bgimage, rect)
         pygame.display.update()
 
     def _render_text(self, message, font=None):

--- a/video_looper.ini
+++ b/video_looper.ini
@@ -36,6 +36,10 @@ osd = true
 # To play random playlist.
 is_random = false
 
+# Change the background with a custom image
+# This image is displayed between movies
+#bgimage = /home/pi/bg.png
+
 # Change the color of the background that is displayed behind movies (only works
 # with omxplayer).  Provide 3 numeric values from 0 to 255 separated by a commma
 # for the red, green, and blue color value.  Default is 0, 0, 0 or black.


### PR DESCRIPTION
I needed this option to fake a gapless change of video in a playlist.
All my videos finish with the same logo, so I used an image of this last frame, which is displayed between videos.

Folks could also use this feature to show a wallpaper between videos.
