### PR TITLE
ESC exits program, if keyboard control is enabled

### DIFF
--- a/video_looper.ini
+++ b/video_looper.ini
@@ -36,6 +36,11 @@ osd = true
 # To play random playlist.
 is_random = false
 
+# Control the program via keyboard
+# If enabled, hit ESC key to quit the program anytime (except countdown).
+keyboard_control = false
+#keyboard_control = true
+
 # Change the color of the background that is displayed behind movies (only works
 # with omxplayer).  Provide 3 numeric values from 0 to 255 separated by a commma
 # for the red, green, and blue color value.  Default is 0, 0, 0 or black.


### PR DESCRIPTION
You can set keyboard control in config file. If enambed, you can
exit video looper by pressing ESC key any time (except countdown).

Sometimes you want to exit this presentation, for some reasons and you have no remote access to your pi, but you have keyboard access.

So I added keyboard_control parameter to config. By default it is disabled, to keep original functionality and speed.

If enabled it allows you to exit program by hitting the ESC key any time. If countown is displayed and you hit ESC, it wil exit the program after countdown is finished. It also displays a message about this on idle screen.
