### PR TITLE
alsa support

### DIFF
--- a/Adafruit_Video_Looper/alsa_config.py
+++ b/Adafruit_Video_Looper/alsa_config.py
@@ -1,0 +1,12 @@
+import re
+
+def parse_hw_device(s):
+    if not s:
+        return None
+
+    m = re.match("^(\d+),(\d+)$", s)
+
+    if not m:
+        raise RuntimeError('Invalid value for alsa hardware device: {}'.format(s))
+    
+    return tuple(map(int, m.group(1, 2)))

--- a/Adafruit_Video_Looper/omxplayer.py
+++ b/Adafruit_Video_Looper/omxplayer.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import time
 
+from .alsa_config import parse_hw_device
 
 class OMXPlayer:
 
@@ -33,7 +34,10 @@ class OMXPlayer:
                                  .split(',')
         self._extra_args = config.get('omxplayer', 'extra_args').split()
         self._sound = config.get('omxplayer', 'sound').lower()
-        assert self._sound in ('hdmi', 'local', 'both'), 'Unknown omxplayer sound configuration value: {0} Expected hdmi, local, or both.'.format(self._sound)
+        assert self._sound in ('hdmi', 'local', 'both', 'alsa'), 'Unknown omxplayer sound configuration value: {0} Expected hdmi, local, both or alsa.'.format(self._sound)
+        self._alsa_hw_device = parse_hw_device(config.get('alsa', 'hw_device'))
+        if self._alsa_hw_device != None and self._sound == 'alsa':
+            self._sound = 'alsa:hw:{},{}'.format(self._alsa_hw_device[0], self._alsa_hw_device[1])
         self._show_titles = config.getboolean('omxplayer', 'show_titles')
         if self._show_titles:
             title_duration = config.getint('omxplayer', 'title_duration')

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ If you miss a feature just post an issue on github. (https://github.com/adafruit
 
 ## Changelog
 
+#### new in v1.0.6
+
+ - Support for OMXPlayer ALSA sound output.  
+   Enabled by setting `omxplayer.sound` to `alsa`. A new config key `alsa.hw_device` can be used to specify a non-default output device.
+ - Support for ALSA hardware volume control.  
+   The new config keys `alsa.hw_vol_file` and `alsa.hw_vol_control` can be used to set the output device volume based on a text file provided with the videos.
+ - The `sound_vol_file` functionality can now be disabled by leaving the config value empty.
+
 #### new in v1.0.5
 
  - Support for M3U playlists.  

--- a/assets/video_looper.ini
+++ b/assets/video_looper.ini
@@ -128,6 +128,8 @@ path =
 #path = playlist.m3u
 
 
+# ALSA configuration follows.
+# This only applies when using omxplayer with sound = alsa.
 [alsa]
 
 # ALSA hardware device to use for sound output.  This consists of the card

--- a/assets/video_looper.ini
+++ b/assets/video_looper.ini
@@ -127,6 +127,30 @@ password = videopi
 path = 
 #path = playlist.m3u
 
+
+[alsa]
+
+# ALSA hardware device to use for sound output.  This consists of the card
+# number and subdevice number separated by a comma, e.g. '1,0'.  Run 
+# 'aplay -l' to list available devices.  If empty, the default output device is
+# used.
+hw_device = 
+#hw_device = 1,0
+
+# Volume of the hardware device can be set using a text file provided with the
+# video files.  If the file does not exist, the hardware volume will remain
+# unchanged.  This setting specifies the name of the text file.
+# The file should contain a single line with an amixer-compatible volume value,
+# such as '50%' or '-10db'.
+hw_vol_file =
+#hw_vol_file = alsa_volume
+
+# Name of the ALSA control to use for adjusting volume.  Typically this will be
+# 'PCM'.  Run 'amixer -c N scontrols' (where N is the card number of your output
+# device) to list available controls.
+hw_vol_control = PCM
+
+
 # omxplayer configuration follows.
 [omxplayer]
 
@@ -134,13 +158,16 @@ path =
 # include the dot at the start of the extension.
 extensions = avi, mov, mkv, mp4, m4v
 
-# Sound output for omxplayer, either hdmi, local, or both.  When set to hdmi the
-# video sound will be played on the HDMI output, and when set to local the sound
-# will be played on the analog audio output.  A value of both will play sound on
-# both HDMI and the analog output.  The both value is the default.
+# Sound output for omxplayer, either hdmi, local, both or alsa.  When set to
+# hdmi the video sound will be played on the HDMI output, and when set to local
+# the sound will be played on the analog audio output.  A value of both will
+# play sound on both HDMI and the analog output.  A value of alsa will play
+# sound through ALSA, using the device specified in the [alsa] section above.
+# The both value is the default.
 sound = both
 #sound = hdmi
 #sound = local
+#sound = alsa
 
 # Sound volume output for the video player will be read from  a  file  near  the
 # video files. If the file does not exist, a default volume of 0db will be used.
@@ -148,6 +175,8 @@ sound = both
 # it the value defined below (like 'sound_volume' by default), then inside the
 # file add a single line with the volume value in text to pass to omxplayer (using
 # its --vol option which takes a value in millibels).
+# NOTE: This may introduce audible quantization error. Using hw_vol_file will
+# generally give better sound quality.
 sound_vol_file = sound_volume
 
 # Fixed playlists may embed titles, which can be shown. See playlist section above.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name              = 'Adafruit_Video_Looper',
-      version           = '1.0.5',
+      version           = '1.0.6',
       author            = 'Tony DiCola',
       author_email      = 'tdicola@adafruit.com',
       description       = 'Application to turn your Raspberry Pi into a dedicated looping video playback device, good for art installations, information displays, or just playing cat videos all day.',


### PR DESCRIPTION
hi,

i added some alsa support for my own use case, perhaps you will find it useful as well.

i am using pi_video_looper with a usb audio interface. omxplayer can already play sound to this device via its alsa output, so i added configuration options to pi_video_looper to support this:

* `[omxplayer] sound = alsa` to enable the alsa output
* `[alsa] hw_device` to specify the hardware device (an empty value denotes the default device)

additionally, i found that adjusting sound volume with `[omxplayer] sound_vol_file` can introduce audible quantization error. leaving omxplayer's volume at unity and adjusting the device's volume through e.g. alsamixer sounds better, but this is difficult to do in a headless situation. i added support for doing this via a file as well:

* `[alsa] hw_vol_file` to specify a file that controls the volume. this should contain an amixer-compatible volume value, like `50%` or `-10db`
* `[alsa] hw_vol_control` to specify the name of the device control which adjusts volume (usually `PCM`)

furthermore, i tweaked the `[omxplayer] sound_vol_file` handling to allow leaving the option empty, in which case the functionality is disabled. the same goes for `[alsa] hw_vol_file`.