### PR TITLE
Seed the random number generator

### DIFF
--- a/Adafruit_Video_Looper/model.py
+++ b/Adafruit_Video_Looper/model.py
@@ -4,6 +4,7 @@
 import random
 from typing import Optional
 
+random.seed()
 
 class Movie:
     """Representation of a movie"""


### PR DESCRIPTION
Minor change to model.py, which handles randomization for playlists.

A comment from the Adafruit forums suggested the RNG repeats the same number pattern on some platforms.

Adding a call to random.seed(), whose default behavior is to feed the RNG a starting value from the system clock, or from some other OS-level random source, fixed the problem.