### PR TITLE
Fix for falseley adding media of the wrong extension

### DIFF
--- a/Adafruit_Video_Looper/usb_drive_copymode.py
+++ b/Adafruit_Video_Looper/usb_drive_copymode.py
@@ -95,12 +95,12 @@ class USBDriveReaderCopy(object):
             if copy_mode == "replace":
                 # iterate over target path for deleting:
                 for x in os.listdir(self._target_path):
-                    if x[0] is not '.' and re.search('\.{0}$'.format(self._extensions), x, flags=re.IGNORECASE):
+                    if x[0] is not '.' and re.search('\.({0})$'.format(self._extensions), x, flags=re.IGNORECASE):
                         os.remove('{0}/{1}'.format(self._target_path.rstrip('/'), x))
 
             # iterate over source path for copying:
             for x in os.listdir(path):
-                if x[0] is not '.' and re.search('\.{0}$'.format(self._extensions), x, flags=re.IGNORECASE):
+                if x[0] is not '.' and re.search('\.({0})$'.format(self._extensions), x, flags=re.IGNORECASE):
                     #copy file
                     self.copy_with_progress('{0}/{1}'.format(path.rstrip('/'), x), '{0}/{1}'.format(self._target_path.rstrip('/'), x))
 

--- a/Adafruit_Video_Looper/video_looper.py
+++ b/Adafruit_Video_Looper/video_looper.py
@@ -193,7 +193,7 @@ class VideoLooper:
 
             for x in os.listdir(path):
                 # Ignore hidden files (useful when file loaded on usb key from an OSX computer
-                if x[0] is not '.' and re.search('\.{0}$'.format(self._extensions), x, flags=re.IGNORECASE):
+                if x[0] is not '.' and re.search('\.({0})$'.format(self._extensions), x, flags=re.IGNORECASE):
                     repeatsetting = re.search('_repeat_([0-9]*)x', x, flags=re.IGNORECASE)
                     if (repeatsetting is not None):
                         repeat = repeatsetting.group(1)


### PR DESCRIPTION
Noticed media of the wrong type was being added to the playlist because their names contained a valid extension in the middle. Added parentheses around the extension formatter so the $ end character and . start character is applied to all extensions in the list instead of just the ones on the end

Example from before:
    extensions = 'mp4|mov|m4v'
    x = 'movie.mkv'
    re.search('\.({0})$'.format(extensions), x, flags=re.IGNORECASE)    # would yield a match for mov because the re looked for matches on '.mp4' 'mov' and 'm4v$'

