### PR TITLE
RasPiOS “Bullseye” support via cvlc

### DIFF
--- a/Adafruit_Video_Looper/cvlcplayer.py
+++ b/Adafruit_Video_Looper/cvlcplayer.py
@@ -32,21 +32,21 @@ class CVLCPlayer:
         self._extensions = config.get('cvlc', 'extensions') \
                                  .translate(str.maketrans('', '', ' \t\r\n.')) \
                                  .split(',')
-        self._extra_args = config.get('cvlc', 'extra_args').split()
-        self._sound = config.get('cvlc', 'sound').lower()
-        assert self._sound in ('hdmi', 'local', 'both', 'alsa'), 'Unknown cvlc sound configuration value: {0} Expected hdmi, local, both or alsa.'.format(self._sound)
-        self._alsa_hw_device = parse_hw_device(config.get('alsa', 'hw_device'))
-        if self._alsa_hw_device != None and self._sound == 'alsa':
-            self._sound = 'alsa:hw:{},{}'.format(self._alsa_hw_device[0], self._alsa_hw_device[1])
-        self._show_titles = config.getboolean('cvlc', 'show_titles')
-        if self._show_titles:
-            title_duration = config.getint('cvlc', 'title_duration')
-            if title_duration >= 0:
-                m, s = divmod(title_duration, 60)
-                h, m = divmod(m, 60)
-                self._subtitle_header = '00:00:00,00 --> {:d}:{:02d}:{:02d},00\n'.format(h, m, s)
-            else:
-                self._subtitle_header = '00:00:00,00 --> 99:59:59,00\n'
+        #self._extra_args = config.get('cvlc', 'extra_args').split()
+        #self._sound = config.get('cvlc', 'sound').lower()
+        #assert self._sound in ('hdmi', 'local', 'both', 'alsa'), 'Unknown cvlc sound configuration value: {0} Expected hdmi, local, both or alsa.'.format(self._sound)
+        #self._alsa_hw_device = parse_hw_device(config.get('alsa', 'hw_device'))
+        #if self._alsa_hw_device != None and self._sound == 'alsa':
+        #    self._sound = 'alsa:hw:{},{}'.format(self._alsa_hw_device[0], self._alsa_hw_device[1])
+        #self._show_titles = config.getboolean('cvlc', 'show_titles')
+        #if self._show_titles:
+        #    title_duration = config.getint('cvlc', 'title_duration')
+        #    if title_duration >= 0:
+        #        m, s = divmod(title_duration, 60)
+        #        h, m = divmod(m, 60)
+        #        self._subtitle_header = '00:00:00,00 --> {:d}:{:02d}:{:02d},00\n'.format(h, m, s)
+        #    else:
+        #        self._subtitle_header = '00:00:00,00 --> 99:59:59,00\n'
 
     def supported_extensions(self):
         """Return list of supported file extensions."""
@@ -56,9 +56,9 @@ class CVLCPlayer:
         """Play the provided movie file, optionally looping it repeatedly."""
         self.stop(3)  # Up to 3 second delay to let the old player stop.
         # Assemble list of arguments.
-        args = ['cvlc']
+        args = ['sudo', '-u','pi', 'cvlc']
         #args.extend(['-o', self._sound])  # Add sound arguments.
-        args.extend(self._extra_args)     # Add extra arguments from config.
+        #args.extend(self._extra_args)     # Add extra arguments from config.
         #if vol is not 0:
         #    args.extend(['--vol', str(vol)])
         if loop is None:
@@ -67,14 +67,14 @@ class CVLCPlayer:
             args.append('--loop')  # Add loop parameter if necessary.
         else:
             args.append('--play-and-exit')
-        if self._show_titles and movie.title:
-            srt_path = os.path.join(self._get_temp_directory(), 'video_looper.srt')
-            with open(srt_path, 'w') as f:
-                f.write(self._subtitle_header)
-                f.write(movie.title)
-            args.extend(['--subtitles', srt_path])
-        else:
-            args.append('--no-osd')
+        #if self._show_titles and movie.title:
+        #    srt_path = os.path.join(self._get_temp_directory(), 'video_looper.srt')
+        #    with open(srt_path, 'w') as f:
+        #        f.write(self._subtitle_header)
+        #        f.write(movie.title)
+        #    args.extend(['--subtitles', srt_path])
+        #else:
+        #    args.append('--no-osd')
         args.append(movie.filename)       # Add movie file path.
         # Run cvlc process and direct standard output to /dev/null.
         self._process = subprocess.Popen(args,
@@ -96,7 +96,7 @@ class CVLCPlayer:
         if self._process is not None and self._process.returncode is None:
             # There are a couple processes used by cvlc, so kill both
             # with a pkill command.
-            subprocess.call(['pkill', '-9', 'cvlc'])
+            subprocess.call(['pkill', '-9', 'vlc'])
         # If a blocking timeout was specified, wait up to that amount of time
         # for the process to stop.
         start = time.time()

--- a/Adafruit_Video_Looper/cvlcplayer.py
+++ b/Adafruit_Video_Looper/cvlcplayer.py
@@ -112,6 +112,6 @@ class CVLCPlayer:
         return False
 
 
-def create_player(config):
+def create_player(config, **kwargs):
     """Create new video player based on cvlc."""
     return CVLCPlayer(config)

--- a/Adafruit_Video_Looper/cvlcplayer.py
+++ b/Adafruit_Video_Looper/cvlcplayer.py
@@ -1,0 +1,113 @@
+# Copyright 2015 Adafruit Industries.
+# Author: Tony DiCola
+# License: GNU GPLv2, see LICENSE.txt
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+from .alsa_config import parse_hw_device
+
+class CVLCPlayer:
+
+    def __init__(self, config):
+        """Create an instance of a video player that runs omxplayer in the
+        background.
+        """
+        self._process = None
+        self._temp_directory = None
+        self._load_config(config)
+
+    def __del__(self):
+        if self._temp_directory:
+            shutil.rmtree(self._temp_directory)
+
+    def _get_temp_directory(self):
+        if not self._temp_directory:
+            self._temp_directory = tempfile.mkdtemp()
+        return self._temp_directory
+
+    def _load_config(self, config):
+        self._extensions = config.get('omxplayer', 'extensions') \
+                                 .translate(str.maketrans('', '', ' \t\r\n.')) \
+                                 .split(',')
+        self._extra_args = config.get('omxplayer', 'extra_args').split()
+        self._sound = config.get('omxplayer', 'sound').lower()
+        assert self._sound in ('hdmi', 'local', 'both', 'alsa'), 'Unknown omxplayer sound configuration value: {0} Expected hdmi, local, both or alsa.'.format(self._sound)
+        self._alsa_hw_device = parse_hw_device(config.get('alsa', 'hw_device'))
+        if self._alsa_hw_device != None and self._sound == 'alsa':
+            self._sound = 'alsa:hw:{},{}'.format(self._alsa_hw_device[0], self._alsa_hw_device[1])
+        self._show_titles = config.getboolean('omxplayer', 'show_titles')
+        if self._show_titles:
+            title_duration = config.getint('omxplayer', 'title_duration')
+            if title_duration >= 0:
+                m, s = divmod(title_duration, 60)
+                h, m = divmod(m, 60)
+                self._subtitle_header = '00:00:00,00 --> {:d}:{:02d}:{:02d},00\n'.format(h, m, s)
+            else:
+                self._subtitle_header = '00:00:00,00 --> 99:59:59,00\n'
+
+    def supported_extensions(self):
+        """Return list of supported file extensions."""
+        return self._extensions
+
+    def play(self, movie, loop=None, vol=0):
+        """Play the provided movie file, optionally looping it repeatedly."""
+        self.stop(3)  # Up to 3 second delay to let the old player stop.
+        # Assemble list of arguments.
+        args = ['omxplayer']
+        args.extend(['-o', self._sound])  # Add sound arguments.
+        args.extend(self._extra_args)     # Add extra arguments from config.
+        if vol is not 0:
+            args.extend(['--vol', str(vol)])
+        if loop is None:
+            loop = movie.repeats
+        if loop <= -1:
+            args.append('--loop')  # Add loop parameter if necessary.
+        if self._show_titles and movie.title:
+            srt_path = os.path.join(self._get_temp_directory(), 'video_looper.srt')
+            with open(srt_path, 'w') as f:
+                f.write(self._subtitle_header)
+                f.write(movie.title)
+            args.extend(['--subtitles', srt_path])
+        args.append(movie.filename)       # Add movie file path.
+        # Run omxplayer process and direct standard output to /dev/null.
+        self._process = subprocess.Popen(args,
+                                         stdout=open(os.devnull, 'wb'),
+                                         close_fds=True)
+
+    def is_playing(self):
+        """Return true if the video player is running, false otherwise."""
+        if self._process is None:
+            return False
+        self._process.poll()
+        return self._process.returncode is None
+
+    def stop(self, block_timeout_sec=0):
+        """Stop the video player.  block_timeout_sec is how many seconds to
+        block waiting for the player to stop before moving on.
+        """
+        # Stop the player if it's running.
+        if self._process is not None and self._process.returncode is None:
+            # There are a couple processes used by omxplayer, so kill both
+            # with a pkill command.
+            subprocess.call(['pkill', '-9', 'omxplayer'])
+        # If a blocking timeout was specified, wait up to that amount of time
+        # for the process to stop.
+        start = time.time()
+        while self._process is not None and self._process.returncode is None:
+            if (time.time() - start) >= block_timeout_sec:
+                break
+            time.sleep(0)
+        # Let the process be garbage collected.
+        self._process = None
+
+    @staticmethod
+    def can_loop_count():
+        return False
+
+
+def create_player(config):
+    """Create new video player based on cvlc."""
+    return CVLCPlayer(config)

--- a/README.md
+++ b/README.md
@@ -6,18 +6,24 @@ Easy to use out of the box but also has a lot of settings to make it fit your us
 
 If you miss a feature just post an issue on github. (https://github.com/adafruit/pi_video_looper)
 
+With the current Raspberry Pi OS Version 11 (bullseye) only cvlc and image_player are supported.  
+If you still want or need to use omxplayer or hello_video you need to install Raspberry Pi OS Lite __(Legacy)__.  
+You can download it from here: https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-legac
+
 There are also pre-compiled versions available from: https://videolooper.de/ (but they might not contain the latest version of pi_video_looper)
 
 ## Changelog
+#### new in v1.1.0
+ - NEW PLAYER: cvlc  
+   since Rasperry Pi OS 11 (bullseye) omxplayer and hello_video are no longer supported.  
+   cvlc can be used with the legacy os as well. The install script automatically installs the appropriate dependencies for your system.
+
 #### new in v1.0.10
  - NEW PLAYER: "Image Player" (beta)  
    The new player can display images instead of videos (slideshow).  
    Display duration and other options can be controlled via "image_player" section in ini  
    All other settings, like background image, color, wait time, copy mode, keyboard shortcuts, etc. should work as expected  
    Currently tested formats: jpg, gif, png (others might work also - you need to adapt the extensions setting)
-
-#### new in v1.1.0
- - Only cvlc is used for video playback. omxplayer and hello_video no longer work as of RasPiOS Bullseye. cvlc currently requires using the "fake" KMS device tree overlay; the install script sets this up.
 
 #### new in v1.0.9
  - fixed: background image is reloaded in copymode without restart

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Easy to use out of the box but also has a lot of settings to make it fit your us
 
 If you miss a feature just post an issue on github. (https://github.com/adafruit/pi_video_looper)
 
-Currently only Raspberry Pi OS Lite __(Legacy)__ is supported.
-You can download it from here: https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-legacy
-
 There are also pre-compiled versions available from: https://videolooper.de/ (but they might not contain the latest version of pi_video_looper)
 
 ## Changelog
+
+#### new in v1.1.0
+ - Only cvlc is used for video playback. omxplayer and hello_video no longer work as of RasPiOS Bullseye. cvlc currently requires using the "fake" KMS device tree overlay; the install script sets this up.
 
 #### new in v1.0.9
  - fixed: background image is reloaded in copymode without restart

--- a/assets/video_looper.ini
+++ b/assets/video_looper.ini
@@ -6,14 +6,21 @@
 # Video looper configuration block follows.
 [video_looper]
 
-# set which video player will be used to play movies.  Can be either omxplayer or
-# hello_video.  omxplayer can play common formats like avi, mov, mp4, etc. and
+# Set which video player will be used to play movies.  Currently ONLY cvlc
+# is used; omxplayer and hello_video no longer work and/or are unavailable
+# as of RasPiOS Bullseye.  cvlc supports a ton of formats and should handle
+# just about anything.  Scripts and settings for the other players are kept
+# around for the time being, for reference or if one stages a comback, but
+# at some point can be safely deleted.
+video_player = cvlc
+#video_player = omxplayer
+#video_player = hello_video
+# OLD NOTES: omxplayer can play common formats like avi, mov, mp4, etc. and
 # with full audio and video, but it has a small ~100ms delay between videos.
 # if there is only one video omxplayer can also loop seamlessly
-# hello_video is a simpler player that doesn't do audio and only plays raw H264
-# streams, but loops videos seamlessly if one video is played more than once.  The default is omxplayer.
-video_player = omxplayer
-#video_player = hello_video
+# hello_video is a simpler player that doesn't do audio and only plays raw
+# H264 streams, but loops videos seamlessly if one video is played more than
+# once.  The default is omxplayer.
 
 # Where to find movie files.  Can be either usb_drive or directory.  When using
 # usb_drive any USB stick inserted in to the Pi will be automatically mounted
@@ -132,6 +139,15 @@ path =
 #path = playlist.m3u
 
 
+# cvlc player configuration follows.
+[cvlc]
+
+# CONFIGURATION SETTINGS BELOW THIS LINE ARE DEPRECATED. omxplayer and
+# hello_video no longer work in RasPiOS Bullseye, these settings are just
+# kept for reference until it's determined that can all be pulled out.
+# (The ALSA stuff might stay if cvlc works along with that.)
+
+
 # ALSA configuration follows.
 # This only applies when using omxplayer with sound = alsa.
 [alsa]
@@ -155,7 +171,6 @@ hw_vol_file =
 # 'PCM'.  Run 'amixer -c N scontrols' (where N is the card number of your output
 # device) to list available controls.
 hw_vol_control = PCM
-
 
 # omxplayer configuration follows.
 [omxplayer]

--- a/assets/video_looper.ini
+++ b/assets/video_looper.ini
@@ -6,25 +6,12 @@
 # Video looper configuration block follows.
 [video_looper]
 
-<<<<<<< HEAD
 # Set which video player will be used to play movies. Since Raspberry Pi OS 11 only cvlc
 # is supported for playing videos. cvlc supports a ton of formats and should handle
 # just about anything. 
 # The image_player only displays images for the duration configured in this file under the "image_player" section.
 # The default is cvlc.
 video_player = cvlcplayer
-=======
-# set which video player will be used to play movies.  Can be either omxplayer or
-# hello_video.  omxplayer can play common formats like avi, mov, mp4, etc. and
-# with full audio and video, but it has a small ~100ms delay between videos.
-# if there is only one video omxplayer can also loop seamlessly
-# hello_video is a simpler player that doesn't do audio and only plays raw H264
-# streams, but loops videos seamlessly if one video is played more than once.
-# The image_player only displays images for the duration configured in this file under the "image_player" section.
-# The default is omxplayer.
-video_player = omxplayer
-#video_player = hello_video
->>>>>>> 067826daf26b666cab40b00fba0251d0c78e14c5
 #video_player = image_player
 
 # Where to find movie files.  Can be either usb_drive or directory.  When using
@@ -228,16 +215,6 @@ extra_args = --no-osd --audio_fifo 0.01 --video_fifo 0.01 --align center --font-
 
 # List of supported file extensions.  Must be comma separated and should not
 # include the dot at the start of the extension.
-<<<<<<< HEAD
-=======
-extensions = h264
-
-# image player configuration follows
-[image_player]
-
-# List of supported file extensions.  Must be comma separated and should not
-# include the dot at the start of the extension.
->>>>>>> 067826daf26b666cab40b00fba0251d0c78e14c5
 extensions = jpg, jpeg, gif, png
 
 # Seconds an image is displayed

--- a/assets/video_looper_legacy.ini
+++ b/assets/video_looper_legacy.ini
@@ -6,13 +6,18 @@
 # Video looper configuration block follows.
 [video_looper]
 
-# Set which video player will be used to play movies. Since Raspberry Pi OS 11 only cvlc
-# is supported for playing videos. cvlc supports a ton of formats and should handle
-# just about anything. 
+# set which video player will be used to play movies.  Can be either omxplayer or
+# hello_video.  omxplayer can play common formats like avi, mov, mp4, etc. and
+# with full audio and video, but it has a small ~100ms delay between videos.
+# if there is only one video omxplayer can also loop seamlessly
+# hello_video is a simpler player that doesn't do audio and only plays raw H264
+# streams, but loops videos seamlessly if one video is played more than once.
 # The image_player only displays images for the duration configured in this file under the "image_player" section.
-# The default is cvlc.
-video_player = cvlcplayer
+# The default is omxplayer.
+video_player = omxplayer
+#video_player = hello_video
 #video_player = image_player
+#video_player = cvlcplayer
 
 # Where to find movie files.  Can be either usb_drive or directory.  When using
 # usb_drive any USB stick inserted in to the Pi will be automatically mounted
@@ -61,14 +66,14 @@ keyboard_control = true
 #keyboard_control = false
 
 # Set the background to a custom image
-# This image is displayed between movies
-# Can potentially look broken if video resolution is smaller than display resolution
+# This image is displayed between movies or images
+# it image will be scaled to the display resolution and centered
 # bgimage = /home/pi/loader.png
 bgimage = 
 
 # Change the color of the background that is displayed behind movies (only works
-# with omxplayer).  Provide 3 numeric values from 0 to 255 separated by a commma
-# for the red, green, and blue color value.  Default is 0, 0, 0 or black.
+# with omxplayer and the image_player).  Provide 3 numeric values from 0 to 255 separated by a commma
+# for the red, green, and blue color value.  Default is 0, 0, 0 which is black.
 bgcolor = 0, 0, 0
 
 # Change the color of the foreground text that is displayed with the on screen
@@ -131,21 +136,8 @@ path =
 #path = playlist.m3u
 
 
-# cvlc player configuration follows.
-[cvlc]
-
-# List of supported file extensions.  Must be comma separated and should not
-# include the dot at the start of the extension.
-extensions = avi, mov, mkv, mp4, m4v
-
-# CONFIGURATION SETTINGS BELOW THIS LINE ARE DEPRECATED. omxplayer and
-# hello_video no longer work in RasPiOS Bullseye, these settings are just
-# kept for reference until it's determined that can all be pulled out.
-# (The ALSA stuff might stay if cvlc works along with that.)
-
-
 # ALSA configuration follows.
-# This only applies when using cvlc with sound = alsa.
+# This only applies when using omxplayer with sound = alsa.
 [alsa]
 
 # ALSA hardware device to use for sound output.  This consists of the card
@@ -167,6 +159,7 @@ hw_vol_file =
 # 'PCM'.  Run 'amixer -c N scontrols' (where N is the card number of your output
 # device) to list available controls.
 hw_vol_control = PCM
+
 
 # omxplayer configuration follows.
 [omxplayer]
@@ -209,6 +202,13 @@ title_duration = 10
 # video FIFO buffers are kept low to reduce clipping ends of movie at loop.
 # Run 'omxplayer -h' to have the full list of parameters.
 extra_args = --no-osd --audio_fifo 0.01 --video_fifo 0.01 --align center --font-size 55
+
+# hello_video player configuration follows.
+[hello_video]
+
+# List of supported file extensions.  Must be comma separated and should not
+# include the dot at the start of the extension.
+extensions = h264
 
 # image player configuration follows
 [image_player]

--- a/install.sh
+++ b/install.sh
@@ -30,9 +30,13 @@ fi
 # Error out if anything fails. Must be set AFTER grep calls above.
 set -e
 
+echo "Updating system..."
+echo "==================
+apt update && apt upgrade -y
+
 echo "Installing dependencies..."
 echo "=========================="
-apt update && apt upgrade && apt -y install python3 python3-pip python3-pygame supervisor ntfs-3g exfat-fuse vlc
+apt -y install python3 python3-pip python3-pygame supervisor ntfs-3g exfat-fuse vlc
 
 echo "Installing video_looper program..."
 echo "=================================="

--- a/install.sh
+++ b/install.sh
@@ -6,61 +6,99 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-echo "Configuring device tree overlays..."
-echo "==================================="
-
-# VLC requires "fake" KMS overlay to work in Bullseye.
-# Check /boot/config.txt for vc4-fkms-v3d overlay present and active.
-# If so, nothing to do here, module's already configured.
-PROMPT_FOR_REBOOT=0
-grep '^dtoverlay=vc4-fkms-v3d' /boot/config.txt >/dev/null
-if [ $? -ne 0 ]; then
-  # fkms overlay not present, or is commented out. Check if vc4-kms-v3d
-  # (no 'f') is present and active. That's normally the default.
-  grep '^dtoverlay=vc4-kms-v3d' /boot/config.txt >/dev/null
-  if [ $? -eq 0 ]; then
-    # It IS present. Comment out that line, and insert the 'fkms' item
-    # on the next line.
-    sed -i "s/^dtoverlay=vc4-kms-v3d/#&\ndtoverlay=vc4-fkms-v3d/g" /boot/config.txt >/dev/null
-  else
-    # It's NOT present. Silently append 'fkms' overlay to end of file.
-    echo dtoverlay=vc4-fkms-v3d | sudo tee -a /boot/config.txt >/dev/null
-  fi
-  # Any change or addition of overlay will require a reboot when done.
-  PROMPT_FOR_REBOOT=1
-fi
-
-# Error out if anything fails. Must be set AFTER grep calls above.
-set -e
-
-echo "Updating system..."
-echo "=================="
-apt update && apt upgrade -y
-
-echo "Installing dependencies..."
-echo "=========================="
-apt -y install python3 python3-pip python3-pygame supervisor ntfs-3g exfat-fuse vlc
-
-echo "Installing video_looper program..."
-echo "=================================="
-
 # change the directoy to the script location
 cd "$(dirname "$0")"
+
+# Basic system prep
+echo "Installing dependencies..."
+echo "=========================="
+apt update && apt -y install python3 python3-pip python3-pygame supervisor ntfs-3g exfat-fuse
 
 mkdir -p /mnt/usbdrive0 # This is very important if you put your system in readonly after
 mkdir -p /home/pi/video # create default video directory
 
+# Determine OS and run legacy installer
+if [ "$(grep '^VERSION_ID=' /etc/os-release | grep -ioP '[[:digit:]]+')" -gt 10 ]; then
+
+  echo "Installing version for bulseye (or higher)..."
+  echo "==================================="
+  echo "omxplayer and hello_video are not available"
+  echo "==================================="
+
+  echo "Configuring device tree overlays..."
+  echo "==================================="
+
+  # VLC requires "fake" KMS overlay to work in Bullseye.
+  # Check /boot/config.txt for vc4-fkms-v3d overlay present and active.
+  # If so, nothing to do here, module's already configured.
+  PROMPT_FOR_REBOOT=0
+  grep '^dtoverlay=vc4-fkms-v3d' /boot/config.txt >/dev/null
+  if [ $? -ne 0 ]; then
+    # fkms overlay not present, or is commented out. Check if vc4-kms-v3d
+    # (no 'f') is present and active. That's normally the default.
+    grep '^dtoverlay=vc4-kms-v3d' /boot/config.txt >/dev/null
+    if [ $? -eq 0 ]; then
+      # It IS present. Comment out that line, and insert the 'fkms' item
+      # on the next line.
+      sed -i "s/^dtoverlay=vc4-kms-v3d/#&\ndtoverlay=vc4-fkms-v3d/g" /boot/config.txt >/dev/null
+    else
+      # It's NOT present. Silently append 'fkms' overlay to end of file.
+      echo dtoverlay=vc4-fkms-v3d | sudo tee -a /boot/config.txt >/dev/null
+    fi
+    # Any change or addition of overlay will require a reboot when done.
+    PROMPT_FOR_REBOOT=1
+  fi
+
+  echo "Installing packages..."
+  echo "=========================="
+  apt -y install vlc
+
+  echo "Copying config..."
+  echo "=========================="
+  cp ./assets/video_looper.ini /boot/video_looper.ini
+
+else
+
+  echo "Installing legacy version..."
+  echo "==================================="
+  echo "==================================="
+
+  echo "Installing packages..."
+  echo "=========================="
+  apt -y install omxplayer
+
+  if [ "$*" != "no_hello_video" ]
+  then
+    echo "Installing hello_video..."
+    echo "========================="
+    apt -y install git build-essential python3-dev
+    git clone https://github.com/adafruit/pi_hello_video
+    cd pi_hello_video
+    ./rebuild.sh
+    cd hello_video
+    make install
+    cd ../..
+    rm -rf pi_hello_video
+  else
+      echo "hello_video was not installed"
+      echo "=========================="
+  fi
+
+  echo "Copying config..."
+  echo "=========================="
+  cp ./assets/video_looper_legacy.ini /boot/video_looper.ini
+
+fi
+
+echo "Installing video_looper program..."
+echo "=================================="
 pip3 install setuptools
 python3 setup.py install --force
-
-cp ./assets/video_looper.ini /boot/video_looper.ini
 
 echo "Configuring video_looper to run on start..."
 echo "==========================================="
 
 cp ./assets/video_looper.conf /etc/supervisor/conf.d/
-
-echo "Finished!"
 
 if [ $PROMPT_FOR_REBOOT -eq 1 ]; then
   echo
@@ -78,3 +116,5 @@ else
   # No reboot needed; can (re)start looper with current DTO config
   service supervisor restart
 fi
+
+echo "Finished!"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Make sure script is run as root.
 if [ "$(id -u)" != "0" ]; then
@@ -75,6 +75,6 @@ if [ $PROMPT_FOR_REBOOT -eq 1 ]; then
     reboot
   fi
 else
-  # No reboot needed; can start looper with current DTO config
+  # No reboot needed; can (re)start looper with current DTO config
   service supervisor restart
 fi

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ fi
 set -e
 
 echo "Updating system..."
-echo "==================
+echo "=================="
 apt update && apt upgrade -y
 
 echo "Installing dependencies..."

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name              = 'Adafruit_Video_Looper',
-      version           = '1.0.9',
+      version           = '1.10.0',
       author            = 'Tony DiCola',
       author_email      = 'tdicola@adafruit.com',
       description       = 'Application to turn your Raspberry Pi into a dedicated looping video playback device, good for art installations, information displays, or just playing cat videos all day.',


### PR DESCRIPTION
Installer now detects the OS version and takes a different path if Bullseye or later. omxplayer and hello_video are no longer supported in the new OS, so cvlc is used there instead, along with some required device tree overlay shenanigans. The older lightweight players can still be used by installing on an earlier OS, if hardware supports it.